### PR TITLE
Move test dependencies into test-dependencies.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,11 @@ before_install:
 
 install:
 - ./dependencies.sh
-- sudo -H pip3 install flake8 pylint
-- git clone https://github.com/mininet/mininet
-- PYTHON=python3 mininet/util/install.sh -nv
+- ./test-dependencies.sh
 
 script:
 - make
-- sudo -E make codecheck  # terrible but mininet == sudo
-# temporary: install patched faucet
-- git clone https://github.com/lantz/faucet -b config_applied
-- (cd faucet; sudo -H python3 setup.py install)
+- make codecheck
 - sudo -E make test
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ FAUCET configuration file (e.g. `faucet.yaml`) via gNMI path `/`.
 ### Simple end-to-end test using Mininet
 
     ./dependencies.sh
+    ./test-dependencies.sh
     make
     sudo make test
 
@@ -40,4 +41,3 @@ FAUCET configuration file (e.g. `faucet.yaml`) via gNMI path `/`.
 [2]: https://travis-ci.org/lantz/faucetagent
 [3]: https://github.com/faucetsdn/faucet
 [4]: https://github.com/google/gnxi
-

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -1,14 +1,15 @@
-#!/bin/bash -x
+#!/bin/bash
+
+GOPATH=${GOPATH:=$HOME/go}
 
 echo "* Installing Python GRPC dependencies"
   sudo apt install python3-pip python3-setuptools python3-wheel
-  pip3 install protobuf grpcio grpcio-tools
+  pip3 -q install protobuf grpcio grpcio-tools requests
   # In case we 'make clean; sudo make test'
-  sudo -H pip3 install protobuf grpcio grpcio-tools
+  sudo pip3 -q install --no-cache protobuf grpcio grpcio-tools requests
 
 echo "* Installing go dependencies"
   sudo apt install golang
-  export GOPATH=$HOME/go
   mkdir -p $GOPATH
   export PATH=$PATH:$GOPATH/bin
 
@@ -20,4 +21,6 @@ echo "* Installing gnxi tools"
   done
 
 echo "* Installing FAUCET as root"
-sudo -H pip3 install faucet
+  sudo pip3 -q install --no-cache --upgrade faucet
+
+echo "* Done"

--- a/makefile
+++ b/makefile
@@ -13,7 +13,7 @@ extstubs = gnmi_ext_pb2.py gnmi_ext_pb2_grpc.py
 protoc = python3 -m grpc_tools.protoc --python_out=. --grpc_python_out=. -I.
 
 # Go path - required for gnmi_{set,get}
-GOPATH = $(HOME)/go
+GOPATH ?= $(HOME)/go
 
 all: $(gnmistubs) $(extstubs)
 
@@ -43,6 +43,5 @@ clean:
 	rm -rf *proto *pb2*py *pyc *~ \#*\# testcerts *log __pycache__ *yaml
 
 test: all
-	pip3 install git+https://github.com/mininet/mininet.git
 	GOPATH=$(GOPATH) PATH=$(GOPATH)/bin:$(PATH) ./agenttest.py
 	grep faucet_config_applied faucetagent.log || true

--- a/test-dependencies.sh
+++ b/test-dependencies.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "* Installing testing (make {test,codecheck}) dependencies"
+  pip3 -q install flake8 pylint
+  TMPDIR=$(mktemp -d) && pushd $TMPDIR
+  git clone https://github.com/mininet/mininet
+  pip3 -q install ./mininet
+  sudo pip3 -q install ./mininet
+  cd mininet && sudo make install-mnexec
+  popd && sudo rm -rf $TMPDIR
+  sudo apt install openvswitch-switch
+  sudo service openvswitch-switch start
+
+echo "* Done"


### PR DESCRIPTION
It should now be possible to test using:

    ./dependencies
    ./test-dependencies
    make
    sudo make test

This should properly install `mnexec` and Mininet so that `sudo make test` can run.

Fixes #4 