### PR TITLE
Verify config file hash against faucet_config_hash{func,info}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ before_install:
 install:
 - ./dependencies.sh
 - ./test-dependencies.sh
+- echo "Testing against latest FAUCET"
+- sudo pip3 -q install git+https://github.com/faucetsdn/faucet
 
 script:
 - make

--- a/agenttest.py
+++ b/agenttest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 r"""
 
 Simple end-to-end test of FAUCET config agent

--- a/makefile
+++ b/makefile
@@ -44,4 +44,4 @@ clean:
 
 test: all
 	GOPATH=$(GOPATH) PATH=$(GOPATH)/bin:$(PATH) ./agenttest.py
-	grep faucet_config_applied faucetagent.log || true
+	grep faucet_config faucetagent.log || true


### PR DESCRIPTION
Now that FAUCET is reporting the config file hashes via `faucet_config_hash_info`, we can use that as the primary signal to verify that our configuration has been accepted (and avoid sending it in the first place if the hash is already the same.)

Previously we had to monitor the config reset counter, wait for it to tick over, and then check for config errors.

The agent log currently reports the hash signals that it used, such as:
```
faucet_config_hash_info={'.../faucetagent/faucet.yaml':
'b2a3e0dd05c22b776482bc241dc1d1f6a4f5a3ed072cc5055e9cbee523c6d186'},
faucet_config_hash_func={'algorithm': 'sha256'})
```

The travis change tests this against the latest and greatest FAUCET. After the next FAUCET release this should no longer be necessary.
