### PR TITLE
Wait for flow table update (+ minor cleanup)

### DIFF
--- a/faucetagent.py
+++ b/faucetagent.py
@@ -9,13 +9,13 @@ FAUCET.
 
 """
 
-from time import sleep, time
-from concurrent import futures
 from argparse import ArgumentParser
-from subprocess import run
-from logging import basicConfig as logConfig, getLogger, DEBUG, INFO
 from collections import namedtuple
+from concurrent import futures
+from logging import basicConfig as logConfig, getLogger, DEBUG, INFO
 from os.path import abspath
+from subprocess import run
+from time import sleep, time
 import hashlib
 
 import requests
@@ -131,7 +131,7 @@ class FaucetProxy:
         }
         for field, value in defaults.items():
             if field not in sdict:
-                warning('this FAUCET does not support %s - faking', field)
+                debug('%s not found (possibly unsupported?)', field)
                 sdict[field] = value
 
         status = self.StatusTuple(**sdict)

--- a/makefile
+++ b/makefile
@@ -45,4 +45,3 @@ clean:
 test: all
 	@echo "* Using GOPATH=$(GOPATH)"
 	GOPATH=$(GOPATH) PATH=$(GOPATH)/bin:$(PATH) ./agenttest.py
-	grep faucet_config faucetagent.log || true

--- a/test-dependencies.sh
+++ b/test-dependencies.sh
@@ -4,8 +4,8 @@ set -e
 PIP3='sudo pip3 -q install --no-cache'
 APT='sudo apt -qq -y install'
 
-echo "* Installing go dependencies"
-  $APT golang
+echo "* Installing apt dependencies"
+  $APT golang iputils-arping
 
 echo "* Checking for go version 1.7 or later"
   goversion=$(go version | awk '{print $3;}')


### PR DESCRIPTION
We assume the flow tables have been updated if a set of new flows (vlan, host MACs) are reported from `ovs-ofctl`.

- send out gratuitous ARPs
- wait for vlan and all host MACs in switch flow tables
- add `iputils-arping` to test-dependencies.sh
