### PR TITLE
Update to new faucet_config_hash_info label format

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -6,6 +6,6 @@ APT='apt -qq -y'
 
 echo "* Installing python dependencies"
   sudo $APT install python3-pip python3-setuptools python3-wheel
-  $PIP3 install protobuf grpcio grpcio-tools requests
+  $PIP3 install protobuf grpcio grpcio-tools requests prometheus_client
 
 echo "* Done"

--- a/test-dependencies.sh
+++ b/test-dependencies.sh
@@ -29,7 +29,7 @@ echo "* Installing gnxi tools"
   done
 
 echo "* Installing python dependencies"
-  $PIP3 flake8 pylint protobuf grpcio grpcio-tools requests
+  $PIP3 flake8 pylint protobuf grpcio grpcio-tools requests prometheus-client
 
 echo "* Installing latest faucet"
   $PIP3 --upgrade git+https://github.com/faucetsdn/faucet


### PR DESCRIPTION
The new format is:

`{config_files='file1,file2', hashes='hash1,hash2'}`

The agent currently only supports one config file/hash, but potentially could support multiple files (i.e. includes) in the future.

Also: switch to using `prometheus_client.parser`

Depends on faucetsdn/faucet#2911 (merged)

Fixes #12