### PR TITLE
Warn on path mismatch (rather than failing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ FAUCET configuration file (e.g. `faucet.yaml`) via gNMI path `/`.
     gnmi_get $AUTH -xpath=/ | string_val
 
     # Send a configuration file to FAUCET
-    gnmi_set $AUTH -replace=/:$(<faucet.yaml)
+    gnmi_set $AUTH -replace=/:"$(<faucet.yaml)"
 
 ### Simple end-to-end test using [mininet][5]
 

--- a/faucetagent.py
+++ b/faucetagent.py
@@ -136,7 +136,8 @@ class FaucetProxy:
             return False
         config_file, hash_value = files[0], hashes[0]
         if abspath(config_file) != self.path:
-            return False
+            warning("FAUCET config file %s may not be %s", config_file,
+                    self.path)
         # Get hash function
         hash_funcs = list(status.faucet_config_hash_func.values())
         if len(hash_funcs) != 1:


### PR DESCRIPTION
Path mismatch should never happen, but it doesn't seem like it should qualify as a catastrophic failure as long as the file hashes match.

Also fix `gnmi_set` command in `README.md`