### PR TITLE
Add and check for fuser/psmisc dependency

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -5,7 +5,7 @@ PIP3='pip3 -q'
 APT='apt -qq -y'
 
 echo "* Installing python dependencies"
-  sudo $APT install python3-pip python3-setuptools python3-wheel
+  sudo $APT install python3-pip python3-setuptools python3-wheel psmisc
   $PIP3 install protobuf grpcio grpcio-tools requests prometheus_client
 
 echo "* Done"

--- a/faucetagent.py
+++ b/faucetagent.py
@@ -14,6 +14,7 @@ from collections import namedtuple
 from concurrent import futures
 from logging import basicConfig as logConfig, getLogger, DEBUG, INFO
 from os.path import abspath
+from shutil import which
 from subprocess import run
 from time import sleep, time
 import hashlib
@@ -41,6 +42,15 @@ def timestamp():
     """Return a gNMI timestamp (int nanoseconds)"""
     seconds = time()
     return int(seconds * 1e9)
+
+
+def checkdeps():
+    """Check external dependencies"""
+    cmds = [('fuser', 'psmisc')]
+    for cmd, pkg in cmds:
+        if not which(cmd):
+            error('Missing "%s" command from %s; exiting', cmd, pkg)
+            exit(1)
 
 
 # Logging
@@ -333,6 +343,7 @@ def parse():
 def main():
     """Parse arguments and run FAUCET gNMI agent"""
     args = parse()
+    checkdeps()
     # FaucetProxy talks to FAUCET and manages configfile
     proxy = FaucetProxy(
         path=args.configfile,


### PR DESCRIPTION
Fixes part 2 of #16, which notes that `psmisc` apparently isn't included in the base installation of Ubuntu 16.04.