### PR TITLE
Add net-tools (ifconfig) and telnet to mininet deps

### DIFF
--- a/test-dependencies.sh
+++ b/test-dependencies.sh
@@ -34,8 +34,8 @@ echo "* Installing python dependencies"
 echo "* Installing latest faucet"
   $PIP3 --upgrade git+https://github.com/faucetsdn/faucet
 
-echo "* Installing openvswitch-switch and latest mininet"
-  $APT openvswitch-switch
+echo "* Installing latest mininet and dependencies"
+  $APT openvswitch-switch net-tools telnet
   sudo service openvswitch-switch start
   TMPDIR=$(mktemp -d) && pushd $TMPDIR
   git clone https://github.com/mininet/mininet


### PR DESCRIPTION
Mininet will currently fail if these are missing,
and they may not be included in current Ubuntu.

Fixes #27