### PR TITLE
Satisfy pylint's ever-stricter, annoying conditions

### DIFF
--- a/agenttest.py
+++ b/agenttest.py
@@ -263,7 +263,7 @@ def wait_server(port, timeout=20):
     """Wait for server to listen on port"""
     cmd, start = ['fuser', '%d/tcp' % port], time()
     while True:
-        if run(cmd, stdout=PIPE).returncode == 0:
+        if run(cmd, stdout=PIPE, check=False).returncode == 0:
             return True
         if time() - start > timeout:
             break
@@ -275,7 +275,7 @@ def kill_server(port, timeout=20):
     """Shut down server listening on port"""
     cmd, start = ['fuser', '-k', '-9', '%d/tcp' % port], time()
     while True:
-        if run(cmd, stdout=PIPE).returncode != 0:
+        if run(cmd, stdout=PIPE, check=False).returncode != 0:
             return True
         if time() - start > timeout:
             break

--- a/faucetagent.py
+++ b/faucetagent.py
@@ -63,6 +63,7 @@ from shutil import which
 from subprocess import run
 from time import sleep, time
 import hashlib
+import sys
 
 import requests
 import grpc
@@ -96,7 +97,7 @@ def checkdeps():
     for cmd, pkg in cmds:
         if not which(cmd):
             error('Missing "%s" command from %s; exiting', cmd, pkg)
-            exit(1)
+            sys.exit(1)
 
 
 # Logging
@@ -436,7 +437,7 @@ def main():
         servicer=agent)
 
     info('FAUCET gNMI configuration agent exiting')
-    exit(0)
+    sys.exit(0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Pylint has added two stupid new rules, which we now comply with:

`subprocess-run-check`: don't use Python's best feature: default values
`consider-using-sys-exit`: because one `exit()` function wasn't enough