### PR TITLE
Use gnmi-gnoi port 9339, assigned by IETF last year

### DIFF
--- a/agenttest.py
+++ b/agenttest.py
@@ -211,7 +211,7 @@ class FAUCET(Controller):
 # it to connect.
 
 GNMI_ADDR = '127.0.0.1'  # Agent listening address (default: [::])
-GNMI_PORT = 10161  # Agent listening port (default: gNMI port 10161)
+GNMI_PORT = 9339  # Agent listening port (default: gNMI port 9339)
 CERT_DIR = 'testcerts'  # We create and destroy this dir to store test certs
 TARGET = 'localhost'  # hostname use in certs and passed to -target
 SUBJ = '/CN=' + TARGET  # Minimal specification for a cert

--- a/faucetagent.py
+++ b/faucetagent.py
@@ -387,7 +387,7 @@ def parse():
     arg('--key', required=True, help='private key file')
     arg('--configfile', required=True, help='FAUCET config file')
     arg('--gnmiaddr', default='[::]', help='gNMI address to listen on ([::])')
-    arg('--gnmiport', type=int, default=10161, help='gNMI port (10161)')
+    arg('--gnmiport', type=int, default=9339, help='gNMI port (9339)')
     arg('--promaddr',
         default='http://localhost',
         help='FAUCET prometheus address (http://localhost)')

--- a/test-dependencies.sh
+++ b/test-dependencies.sh
@@ -26,7 +26,7 @@ echo "* Installing gnxi tools"
   export PATH=$GOPATH/bin:$PATH
   repo=github.com/google/gnxi
   for tool in gnmi_{capabilities,get,set,target}; do
-    go get $repo/$tool
+    go get -u $repo/$tool
     go install $repo/$tool
   done
 


### PR DESCRIPTION
Fixes current build/test failure caused by upstream update of gNxI tools